### PR TITLE
Add app.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # websockethook
 A simple web service to receive web hooks over a web socket.
 
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
 This is a Sinatra based web service. When you run it, you can connect to it using any standard Web Socket client, and register a web hook. When you perform a POST on that newly created web hook, you will receive a message via the web socket.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "name": "websockethook",
+  "description": "A simple web service to receive web hooks over a web socket.",
+  "keywords": ["hook", "websocket"],
+  "addons": [],
+  "env": {}
+}


### PR DESCRIPTION
This adds a simple app.json manifest and a Deploy to Heroku button to the README. This allows the app to be deployed with a couple clicks instead of having to clone the repository.
